### PR TITLE
Fix OFFSET-FETCH clause problem for MS SQL Server prior to 2012

### DIFF
--- a/Dapper.FastCrud/Configuration/OrmConventions.cs
+++ b/Dapper.FastCrud/Configuration/OrmConventions.cs
@@ -115,6 +115,7 @@
             switch (dialect)
             {
                 case SqlDialect.MsSql:
+                case SqlDialect.MsSql2008:
                     return _defaultMsSqlDatabaseOptions;
                 case SqlDialect.PostgreSql:
                     return _defaultPostgreSqlDatabaseOptions;

--- a/Dapper.FastCrud/Configuration/SqlDialect.cs
+++ b/Dapper.FastCrud/Configuration/SqlDialect.cs
@@ -7,9 +7,14 @@ namespace Dapper.FastCrud
     public enum SqlDialect
     {
         /// <summary>
-        /// MS SQL Server
+        /// MS SQL Server 2012 and later
         /// </summary>
         MsSql,
+
+        /// <summary>
+        /// MS SQL Server 2008
+        /// </summary>
+        MsSql2008,
 
         /// <summary>
         /// MySql

--- a/Dapper.FastCrud/EntityDescriptors/TypedEntityDescriptor.cs
+++ b/Dapper.FastCrud/EntityDescriptors/TypedEntityDescriptor.cs
@@ -59,6 +59,9 @@
                 case SqlDialect.MsSql:
                     statementSqlBuilder = new MsSqlBuilder(this, entityMapping);
                     break;
+                case SqlDialect.MsSql2008:
+                    statementSqlBuilder = new MsSql2008Builder(this, entityMapping);
+                    break;
                 case SqlDialect.MySql:
                     statementSqlBuilder = new MySqlBuilder(this, entityMapping);
                     break;

--- a/Dapper.FastCrud/SqlBuilders/MsSql2008Builder.cs
+++ b/Dapper.FastCrud/SqlBuilders/MsSql2008Builder.cs
@@ -1,0 +1,41 @@
+namespace Dapper.FastCrud.SqlBuilders
+{
+    using System;
+    using System.Linq;
+    using Dapper.FastCrud.EntityDescriptors;
+    using Dapper.FastCrud.Mappings;
+
+    internal class MsSql2008Builder : MsSqlBuilder
+    {
+        public MsSql2008Builder(EntityDescriptor entityDescriptor, EntityMapping entityMapping)
+            : base(entityDescriptor, entityMapping, SqlDialect.MsSql)
+        {
+        }
+
+        protected override string ConstructFullSelectStatementInternal(
+            string selectClause,
+            string fromClause,
+            FormattableString whereClause = null,
+            FormattableString orderClause = null,
+            long? skipRowsCount = null,
+            long? limitRowsCount = null,
+            bool forceTableColumnResolution = false)
+        {
+            string orderBySql = (orderClause == null) ? string.Empty : " ORDER BY " + this.ResolveWithSqlFormatter(orderClause, forceTableColumnResolution);
+            string whereSql = (whereClause == null) ? string.Empty : " WHERE " + this.ResolveWithSqlFormatter(whereClause, forceTableColumnResolution);
+
+            if (String.IsNullOrEmpty(orderBySql) || !(skipRowsCount.HasValue || limitRowsCount.HasValue))
+            {
+                return ResolveWithCultureInvariantFormatter($"SELECT {selectClause} FROM {fromClause} {whereSql} {orderBySql}");
+            }
+
+            string sql = "SELECT * FROM (";
+            sql += this.ResolveWithCultureInvariantFormatter($"SELECT {selectClause}, ROW_NUMBER() OVER({orderBySql}) AS [Tu3gD4i0_INDEX] FROM {fromClause} {whereSql}");
+            sql += ") AS Tu3gD4i0";
+            sql += " WHERE " + this.ResolveWithCultureInvariantFormatter($"[Tu3gD4i0_INDEX] BETWEEN {(skipRowsCount ?? 0) + 1} AND {(skipRowsCount ?? 0) + limitRowsCount}");
+            sql += " ORDER BY Tu3gD4i0_INDEX ASC"
+
+            return sql;
+        }
+    }
+}

--- a/Dapper.FastCrud/SqlBuilders/MsSql2008Builder.cs
+++ b/Dapper.FastCrud/SqlBuilders/MsSql2008Builder.cs
@@ -8,7 +8,7 @@ namespace Dapper.FastCrud.SqlBuilders
     internal class MsSql2008Builder : MsSqlBuilder
     {
         public MsSql2008Builder(EntityDescriptor entityDescriptor, EntityMapping entityMapping)
-            : base(entityDescriptor, entityMapping, SqlDialect.MsSql)
+            : base(entityDescriptor, entityMapping, SqlDialect.MsSql2008)
         {
         }
 


### PR DESCRIPTION
The current MsSqlBuilder class generate SQL statement for paging search with OFFSET-FETCH clause, which is only supported by SQL Server from 2012 edition. (see also: https://docs.microsoft.com/en-us/sql/t-sql/queries/select-order-by-clause-transact-sql#Offset) Therefore, we need a separate SqlBuilder class and dialect enum item for SQL Server prior to 2012.

relevant issue: https://github.com/MoonStorm/Dapper.FastCRUD/issues/85