### PR TITLE
Added support for SAP / Sybase Anyhwere SQL dialect

### DIFF
--- a/Dapper.FastCrud/Configuration/DialectOptions/SAnywhereSqlDatabaseOptions.cs
+++ b/Dapper.FastCrud/Configuration/DialectOptions/SAnywhereSqlDatabaseOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace Dapper.FastCrud.Configuration.DialectOptions
+{
+    internal class SAnywhereSqlDatabaseOptions : SqlDatabaseOptions
+    {
+        public SAnywhereSqlDatabaseOptions()
+        {
+            this.StartDelimiter = this.EndDelimiter = "\"";
+            this.ParameterPrefix = this.ParameterSuffix = "?";
+            this.IsUsingSchemas = true;
+        }
+    }
+}

--- a/Dapper.FastCrud/Configuration/OrmConventions.cs
+++ b/Dapper.FastCrud/Configuration/OrmConventions.cs
@@ -23,6 +23,7 @@
         private static readonly SqlDatabaseOptions _defaultMsSqlDatabaseOptions = new MsSqlDatabaseOptions();
         private static readonly SqlDatabaseOptions _defaultMySqlDatabaseOptions = new MySqlDatabaseOptions();
         private static readonly SqlDatabaseOptions _defaultPostgreSqlDatabaseOptions = new PostreSqlDatabaseOptions();
+        private static readonly SqlDatabaseOptions _defaultSAnywhereSqlDatabaseOptions = new SAnywhereSqlDatabaseOptions();
         private static readonly SqlDatabaseOptions _defaultGenericSqlDatabaseOptions = new SqlDatabaseOptions();
 
         private static readonly Type[] _simpleSqlTypes = new[]
@@ -139,6 +140,8 @@
             {
                 case SqlDialect.MsSql:
                     return _defaultMsSqlDatabaseOptions;
+                case SqlDialect.SAnywhereSql:
+                    return _defaultSAnywhereSqlDatabaseOptions;
                 case SqlDialect.PostgreSql:
                     return _defaultPostgreSqlDatabaseOptions;
                 case SqlDialect.MySql:

--- a/Dapper.FastCrud/Configuration/SqlDatabaseOptions.cs
+++ b/Dapper.FastCrud/Configuration/SqlDatabaseOptions.cs
@@ -34,5 +34,10 @@
         /// Gets the prefix used for named parameters
         /// </summary>
         public string ParameterPrefix { get; protected set; }
+
+        /// <summary>
+        /// Gets the suffix used for named parameters
+        /// </summary>
+        public string ParameterSuffix { get; protected set; }
     }
 }

--- a/Dapper.FastCrud/Configuration/SqlDialect.cs
+++ b/Dapper.FastCrud/Configuration/SqlDialect.cs
@@ -24,6 +24,11 @@ namespace Dapper.FastCrud
         /// <summary>
         /// PostgreSql
         /// </summary>
-        PostgreSql
+        PostgreSql,
+
+        /// <summary>
+        /// SAP/Sybase Anywhere SQL
+        /// </summary>
+        SAnywhereSql,
     }
 }

--- a/Dapper.FastCrud/EntityDescriptors/EntityDescriptor(TEntity).cs
+++ b/Dapper.FastCrud/EntityDescriptors/EntityDescriptor(TEntity).cs
@@ -47,6 +47,9 @@
             {
                 case SqlDialect.MsSql:
                     statementSqlBuilder = new MsSqlBuilder(this, entityRegistration);
+                    break;                    
+                case SqlDialect.SAnywhereSql:
+                    statementSqlBuilder = new SAnywhereSqlBuilder(this, entityRegistration);
                     break;
                 case SqlDialect.MySql:
                     statementSqlBuilder = new MySqlBuilder(this, entityRegistration);

--- a/Dapper.FastCrud/SqlBuilders/Dialects/SAnywhereSqlBuilder.cs
+++ b/Dapper.FastCrud/SqlBuilders/Dialects/SAnywhereSqlBuilder.cs
@@ -13,7 +13,7 @@
     internal class SAnywhereSqlBuilder : GenericStatementSqlBuilder
     {
         public SAnywhereSqlBuilder(EntityDescriptor entityDescriptor, EntityRegistration entityRegistration, SqlDialect dialect) 
-            : base(entityDescriptor, entityRegistration, dialect)
+            : base(entityDescriptor, entityRegistration, SqlDialect.SAnywhereSql)
         {
         }
 

--- a/Dapper.FastCrud/SqlBuilders/Dialects/SAnywhereSqlBuilder.cs
+++ b/Dapper.FastCrud/SqlBuilders/Dialects/SAnywhereSqlBuilder.cs
@@ -1,0 +1,103 @@
+﻿namespace Dapper.FastCrud.SqlBuilders.Dialects
+{
+    using Dapper.FastCrud.EntityDescriptors;
+    using Dapper.FastCrud.Mappings.Registrations;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    /// <summary>
+    /// Statement builder for the <seealso cref="SqlDialect.SAnywhereSql"/>.
+    /// </summary>
+    internal class SAnywhereSqlBuilder : GenericStatementSqlBuilder
+    {
+        public SAnywhereSqlBuilder(EntityDescriptor entityDescriptor, EntityRegistration entityRegistration, SqlDialect dialect) 
+            : base(entityDescriptor, entityRegistration, dialect)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a full insert statement
+        /// </summary>
+        protected override string ConstructFullInsertStatementInternal()
+        {
+            if (this.RefreshOnInsertProperties.Length == 0)
+            {
+                return FormattableString.Invariant($"INSERT INTO {this.GetTableName()} ({this.ConstructColumnEnumerationForInsert()}) VALUES ({this.ConstructParamEnumerationForInsert()})");
+            }
+
+            var dbInsertedOutputColumns = string.Join(",", this.RefreshOnInsertProperties.Select(propInfo => $"inserted.{this.GetColumnName(propInfo, null, true)}"));
+            var dbGeneratedColumns = this.ConstructRefreshOnInsertColumnSelection();
+
+            // the union will make the constraints be ignored
+            return FormattableString.Invariant($@"
+                SELECT *
+                    INTO #temp 
+                    FROM (SELECT {dbGeneratedColumns} FROM {this.GetTableName()} WHERE 1=0 
+                        UNION SELECT {dbGeneratedColumns} FROM {this.GetTableName()} WHERE 1=0) as u;
+            
+                INSERT INTO {this.GetTableName()} ({this.ConstructColumnEnumerationForInsert()}) 
+                    OUTPUT {dbInsertedOutputColumns} INTO #temp 
+                    VALUES ({this.ConstructParamEnumerationForInsert()});
+
+                SELECT * FROM #temp");
+        }
+
+        /// <summary>
+        /// Constructs an update statement for a single entity.
+        /// </summary>
+        protected override string ConstructFullSingleUpdateStatementInternal()
+        {
+            if (this.RefreshOnUpdateProperties.Length == 0)
+            {
+                return base.ConstructFullSingleUpdateStatementInternal();
+            }
+
+            var dbUpdatedOutputColumns = string.Join(",", this.RefreshOnUpdateProperties.Select(propInfo => $"inserted.{this.GetColumnName(propInfo, null, true)}"));
+            var dbGeneratedColumns = string.Join(",", this.RefreshOnUpdateProperties.Select(propInfo => $"{this.GetColumnName(propInfo, null, true)}"));
+
+            // the union will make the constraints be ignored
+            return FormattableString.Invariant($@"
+                SELECT *
+                    INTO #temp 
+                    FROM (SELECT {dbGeneratedColumns} FROM {this.GetTableName()} WHERE 1=0 
+                        UNION SELECT {dbGeneratedColumns} FROM {this.GetTableName()} WHERE 1=0) as u;
+
+                UPDATE {this.GetTableName()} 
+                    SET {this.ConstructUpdateClause()}
+                    OUTPUT {dbUpdatedOutputColumns} INTO #temp
+                    WHERE {this.ConstructKeysWhereClause()}
+
+                SELECT * FROM #temp");
+        }
+
+        protected override string ConstructFullSelectStatementInternal(
+            string selectClause,
+            string fromClause,
+            string? whereClause = null,
+            string? orderClause = null,
+            long? skipRowsCount = null,
+            long? limitRowsCount = null)
+        {
+            FormattableString sql = $"SELECT";
+            
+            if (limitRowsCount.HasValue) sql = $"{sql} TOP {limitRowsCount.Value}";
+            if (skipRowsCount.HasValue)  sql = $"{sql} START AT {skipRowsCount.Value}";
+            
+                sql = $"{sql} {selectClause} FROM {fromClause}";
+
+            if (whereClause != null)
+            {
+                sql = $"{sql} WHERE {whereClause}";
+            }
+
+            if (orderClause != null)
+            {
+                sql = $"{sql} ORDER BY {orderClause}";
+            }
+
+            return FormattableString.Invariant(sql);
+        }
+    }
+}

--- a/Dapper.FastCrud/SqlBuilders/Dialects/SAnywhereSqlBuilder.cs
+++ b/Dapper.FastCrud/SqlBuilders/Dialects/SAnywhereSqlBuilder.cs
@@ -85,7 +85,7 @@
             if (limitRowsCount.HasValue) sql = $"{sql} TOP {limitRowsCount.Value}";
             if (skipRowsCount.HasValue)  sql = $"{sql} START AT {skipRowsCount.Value}";
             
-                sql = $"{sql} {selectClause} FROM {fromClause}";
+            sql = $"{sql} {selectClause} FROM {fromClause}";
 
             if (whereClause != null)
             {

--- a/Dapper.FastCrud/SqlBuilders/Dialects/SAnywhereSqlBuilder.cs
+++ b/Dapper.FastCrud/SqlBuilders/Dialects/SAnywhereSqlBuilder.cs
@@ -12,7 +12,7 @@
     /// </summary>
     internal class SAnywhereSqlBuilder : GenericStatementSqlBuilder
     {
-        public SAnywhereSqlBuilder(EntityDescriptor entityDescriptor, EntityRegistration entityRegistration, SqlDialect dialect) 
+        public SAnywhereSqlBuilder(EntityDescriptor entityDescriptor, EntityRegistration entityRegistration) 
             : base(entityDescriptor, entityRegistration, SqlDialect.SAnywhereSql)
         {
         }

--- a/Dapper.FastCrud/SqlBuilders/GenericStatementSqlBuilder.cs
+++ b/Dapper.FastCrud/SqlBuilders/GenericStatementSqlBuilder.cs
@@ -41,6 +41,7 @@
             this.IdentifierStartDelimiter = databaseOptions.StartDelimiter;
             this.IdentifierEndDelimiter = databaseOptions.EndDelimiter;
             this.ParameterPrefix = databaseOptions.ParameterPrefix;
+            this.ParameterSuffix = databaseOptions.ParameterSuffix; // Necessary for Sybase Anyhwere SQL
 
             //_entityRelationships = new ConcurrentDictionary<IStatementSqlBuilder, EntityRelationship>();
             //_regularStatementFormatter = new SqlStatementFormatter(entityDescriptor, entityMapping, this, false);
@@ -98,6 +99,7 @@
         protected string IdentifierEndDelimiter { get; }
         protected bool UsesSchemaForTableNames { get; }
         protected string ParameterPrefix { get; }
+        protected string ParameterSuffix { get; }
 
         #region section for all the methods exposed both publicly and internally
 
@@ -110,7 +112,7 @@
         {
             Requires.NotNullOrEmpty(parameterName, nameof(parameterName));
 
-            return FormattableString.Invariant($"{this.ParameterPrefix}{parameterName}");
+            return FormattableString.Invariant($"{this.ParameterPrefix}{parameterName}{this.ParameterSuffix}");
         }
 
         /// <summary>
@@ -690,7 +692,7 @@
         /// </summary>
         protected virtual string ConstructParamEnumerationForInsertInternal()
         {
-            return string.Join(",", this.InsertProperties.Select(propInfo => $"{this.ParameterPrefix + propInfo.PropertyName}"));
+            return string.Join(",", this.InsertProperties.Select(propInfo => $"{this.ParameterPrefix}{propInfo.PropertyName}{this.ParameterSuffix}"));
         }
 
         /// <summary>
@@ -699,7 +701,7 @@
         /// <param name="tableAlias">Optional table alias.</param>
         protected virtual string ConstructUpdateClauseInternal(string tableAlias = null)
         {
-            return string.Join(",", UpdateProperties.Select(propInfo => $"{this.GetColumnName(propInfo, tableAlias, false)}={this.ParameterPrefix + propInfo.PropertyName}"));
+            return string.Join(",", UpdateProperties.Select(propInfo => $"{this.GetColumnName(propInfo, tableAlias, false)}={this.ParameterPrefix}{propInfo.PropertyName}{this.ParameterSuffix}"));
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Type safety, clean code, less prone to errors, more peace of mind, while still b
 ```
 
 #### Features:
-- Support for LocalDb, Ms Sql Server, MySql, SqLite, PostgreSql and Sybase Anywhere SQL.
+- Support for LocalDb, Ms Sql Server, MySql, SqLite, PostgreSql and SAP/Sybase Anywhere SQL.
 - Entities having composite primary keys are supported, however note that the CRUD operations only support UNIQUE primary keys.
 - Multiple entity mappings are supported, useful for partial queries in large denormalized tables and data migrations between different database types.
 - All the CRUD methods accept a transaction, a command timeout, and a custom entity mapping.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Type safety, clean code, less prone to errors, more peace of mind, while still b
 ```
 
 #### Features:
-- Support for LocalDb, Ms Sql Server, MySql, SqLite, PostgreSql.
+- Support for LocalDb, Ms Sql Server, MySql, SqLite, PostgreSql and Sybase Anywhere SQL.
 - Entities having composite primary keys are supported, however note that the CRUD operations only support UNIQUE primary keys.
 - Multiple entity mappings are supported, useful for partial queries in large denormalized tables and data migrations between different database types.
 - All the CRUD methods accept a transaction, a command timeout, and a custom entity mapping.


### PR DESCRIPTION
I fixed the named parameter issues by adding the possibilty to add a parameter suffix (in SAnywhere SQL its ?paramName?) and made the suffix default to empty string. 

The sybase anywhere implementation is very close to MS SQL, so I only made a few necessary changes.
I tested it in a customer project and so far it seems to work fine. 