### PR TITLE
ModelGenerator: Remove BOM

### DIFF
--- a/Dapper.FastCrud.ModelGenerator/Content/Models/GenericModelGenerator.tt
+++ b/Dapper.FastCrud.ModelGenerator/Content/Models/GenericModelGenerator.tt
@@ -1,4 +1,4 @@
-﻿<#@ assembly name="EnvDTE" #>
+<#@ assembly name="EnvDTE" #>
 <#@ assembly name="System.Core.dll" #>
 <#@ assembly name="System.Data" #>
 <#@ assembly name="System.Data.Entity.Design" #>


### PR DESCRIPTION
Visual Studio does not like the byte order mark and generates a '?' at the start of the output file.
Then the output file is no longer a valid C# file...