### PR TITLE
Fix DiscoverParentChildRelationship  properties list

### DIFF
--- a/Dapper.FastCrud/Mappings/AutoGeneratedEntityMapping.cs
+++ b/Dapper.FastCrud/Mappings/AutoGeneratedEntityMapping.cs
@@ -119,7 +119,7 @@ namespace Dapper.FastCrud.Mappings
             // this can be in the form of:
             //     1. as a marked property of the same type decorated with an InversePropertyAttribute pointing back to our nav property (can even be an entity and not a collection for one-to-one relationships)
             //     2. an unmarked property of type IEnumerable<> OR
-            var parentChildrenPropGroups = TypeDescriptor.GetProperties(entityType)
+            var parentChildrenPropGroups = OrmConfiguration.Conventions.GetEntityProperties(entityType)
                                             .OfType<PropertyDescriptor>()
                                             .Select(prop =>
                                             {


### PR DESCRIPTION
TypeDescriptor.GetProperties incorrectly gets all properties for entityType, ignoring the property filtering set in OrmConfiguration.Conventions.GetEntityProperties

Imagine the code is set up as follows:

https://www.learndapper.com/relationships#dapper-one-to-many-relationships

The entry point of this bug is here:
https://github.com/MoonStorm/FastCrud/blob/a5941a129af58c6bf4e85b43a007dd7dad0f3d4e/Dapper.FastCrud/Mappings/AutoGeneratedEntityMapping.cs#L52

It calls TypeDescriptor.GetProperties
https://github.com/MoonStorm/FastCrud/blob/a5941a129af58c6bf4e85b43a007dd7dad0f3d4e/Dapper.FastCrud/Mappings/AutoGeneratedEntityMapping.cs#L122

which would return **all properties** for Category, including 
`public ICollection<Product> Products { get; set; }`

The execution then leads the following lines / stack :
https://github.com/MoonStorm/FastCrud/blob/a5941a129af58c6bf4e85b43a007dd7dad0f3d4e/Dapper.FastCrud/Mappings/AutoGeneratedEntityMapping.cs#L167

https://github.com/MoonStorm/FastCrud/blob/a5941a129af58c6bf4e85b43a007dd7dad0f3d4e/Dapper.FastCrud/Mappings/AutoGeneratedEntityMapping.cs#L71

This line invokes 
https://github.com/MoonStorm/FastCrud/blob/a5941a129af58c6bf4e85b43a007dd7dad0f3d4e/Dapper.FastCrud/Configuration/OrmConventions.cs#L169

which filters out all properties that are not `IsSimpleSqlType`

using the example provided earlier, this property is NOT returned:
`public Category Category { get; set; }`

causing the code to throw an error : 
https://github.com/MoonStorm/FastCrud/blob/a5941a129af58c6bf4e85b43a007dd7dad0f3d4e/Dapper.FastCrud/Mappings/AutoGeneratedEntityMapping.cs#L181


As observed, DiscoverParentChildren retrieves **all properties** , but DiscoverChildParentRelationships returns only the properties where IsSimpleSqlType == true.

I believe the parent fields should have the same filtering defined in OrmConfiguration.Conventions.GetEntityProperties, which is already extensible via overriding the virtual method.


